### PR TITLE
missing plus signs in parsed examples

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,16 +16,16 @@
         <details>
             <summary> Examples </summary>
             <ul>
-                <li>     <a class="example"> arithmetic             </a>      </li>
-                <li>     <a class="example"> algebra                </a>      </li>
-                <li>     <a class="example"> geometry               </a>      </li>
-                <li>     <a class="example"> statistics             </a>      </li>
-                <li> <b> <a class="example"> calculus               </a> </b> </li>
-                <li> <b> <a class="example"> differential-equations </a> </b> </li>
-                <li>     <a class="example"> discrete-mathematics   </a>      </li>
-                <li>     <a class="example"> linear-algebra         </a>      </li>
-                <li>     <a class="example"> proofs                 </a>      </li>
-                <li>     <a class="example"> chemistry              </a>      </li>
+                <li>     <a class="example"> Arithmetic             </a>      </li>
+                <li>     <a class="example"> Algebra                </a>      </li>
+                <li>     <a class="example"> Geometry               </a>      </li>
+                <li>     <a class="example"> Statistics             </a>      </li>
+                <li> <b> <a class="example"> Calculus               </a> </b> </li>
+                <li> <b> <a class="example"> Differential Equations </a> </b> </li>
+                <li>     <a class="example"> Discrete Mathematics   </a>      </li>
+                <li>     <a class="example"> Linear Algebra         </a>      </li>
+                <li>     <a class="example"> Proofs                 </a>      </li>
+                <li>     <a class="example"> Chemistry              </a>      </li>
             </ul>
         </details>
         <div id="container"> </div>

--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@
                 <li>     <a class="example"> Statistics             </a>      </li>
                 <li> <b> <a class="example"> Calculus               </a> </b> </li>
                 <li> <b> <a class="example"> Differential Equations </a> </b> </li>
-                <li>     <a class="example"> Discrete Mathematics   </a>      </li>
+                <li>     <a class="example"> Discrete Math          </a>      </li>
                 <li>     <a class="example"> Linear Algebra         </a>      </li>
                 <li>     <a class="example"> Proofs                 </a>      </li>
                 <li>     <a class="example"> Chemistry              </a>      </li>

--- a/javascript.js
+++ b/javascript.js
@@ -61,21 +61,17 @@ if (window.onhashchange())
 var browseEexamples = category => {
     displayProgressBar()
     fetch(
-        `${corsProxy}https://www.wolframalpha.com/examples/pro-features/step-by-step-solutions/step-by-step-${category}`
+        `${corsProxy}https://www4c.wolframalpha.com/examples/StepByStep${category.replace(/ /g, '')}-content.html`
     ).then(
         html => html.text()
     ).then(
-        html => container.innerHTML = html.replace(/.*examples-subpage-body../s, '')
-                                          .replace(/subpage-footer-section.*/s, '')
-                                          .replace(/.input..../g, 'http://wolfreealpha.github.io/#')
-                                          .replace(/\+/g, ' ')
-                                          .replace(/&amp;..../g, '')
-                                          .replace(/aside/g, 'aside hidden')
-                                          .replace(/More examples/g, '')
-                                          .replace(/svg /g, '')
+        html => container.innerHTML = html.replace(/.input.*?&amp;lk=3/g, href => href
+                                          .replace(/.input..../, 'http://wolfreealpha.github.io#')
+                                          .replace(/&amp;lk=3/, '')
+                                          .replace(/\+/g, ' '))
     )
 }
 
 document.querySelectorAll('.example').forEach(example =>
-    example.href = `javascript:browseEexamples( '${example.innerText.trim()}' )`
+    example.href = `javascript:browseEexamples( '${example.innerText}' )`
 )


### PR DESCRIPTION
All the plus signs in parsed examples are replaced by whitespace due to the overly permissive regex.