### PR TITLE
include the original copyright/permission notice

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 WolfreeAlpha: FREE Step-by-Step Solution
+Copyright (c) 2020 Lin2Jing4
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
- The original repository [`Free-Wolfram-Step-by-Step-Solution`](https://github.com/Lin2Jing4/Free-Wolfram-Step-by-Step-Solution) is licensed under [the MIT License](https://github.com/Lin2Jing4/Free-Wolfram-Step-by-Step-Solution/blob/main/LICENSE).
- All the content in this new repository [`WolfreeAlpha.github.io`](https://github.com/WolfreeAlpha/WolfreeAlpha.github.io) was copied from The original repository [`Free-Wolfram-Step-by-Step-Solution`](https://github.com/Lin2Jing4/Free-Wolfram-Step-by-Step-Solution) and later modified.
- The original copyright notice and the original permission notice shall be included in this new repository according to [the MIT License](https://github.com/Lin2Jing4/Free-Wolfram-Step-by-Step-Solution/blob/bf2c85ae42a4931542b5a8c50b09c001381f8426/LICENSE#L12).