### PR TITLE
fix: computationally-intensive queries timeout

### DIFF
--- a/javascript.js
+++ b/javascript.js
@@ -49,7 +49,11 @@ const query = async podstate => {
         &podstate = Step-by-step
         &podstate = Show+all+steps
         &podstate = ${podstate}
-        &scantimeout = 20
+        &scantimeout = 999
+        &podtimeout = 999
+        &formattimeout = 999
+        &parsetimeout = 999
+        &totaltimeout = 999
     `
     const response = await fetch(url.replaceAll(' ', ''))
     const xml = await response.text()


### PR DESCRIPTION
The [default timeouts](https://products.wolframalpha.com/api/documentation/#parameter-reference) are too low for computationally-intensive queries such as `integral_(-3)^2 abs(x + x^2 - x^3) dx`. [†](https://github.com/WolfreeAlpha/WolfreeAlpha.github.io/issues/18)